### PR TITLE
fix: add missing bzip2-devel makedepends

### DIFF
--- a/srcpkgs/hyprland-nvidia/template
+++ b/srcpkgs/hyprland-nvidia/template
@@ -24,6 +24,7 @@ makedepends="
 	libglvnd-devel
 	libliftoff
 	libdisplay-info
+	bzip2-devel
 "
 depends="
 	libxcb

--- a/srcpkgs/hyprland/template
+++ b/srcpkgs/hyprland/template
@@ -24,6 +24,7 @@ makedepends="
 	libglvnd-devel
 	libliftoff
 	libdisplay-info
+	bzip2-devel
 "
 depends="
 	libxcb


### PR DESCRIPTION
Couldn't build latest version because `freetype2` depended on `bzip2`