### PR TITLE
Add missing libdrm dependency

### DIFF
--- a/srcpkgs/hyprland/template
+++ b/srcpkgs/hyprland/template
@@ -22,7 +22,7 @@ depends="
 	libxcb
 	libXfixes
 	libxkbcommon
-	libdrm
+	libdrm>=2.4.118
 	pango
 	pixman
 	polkit

--- a/srcpkgs/hyprland/template
+++ b/srcpkgs/hyprland/template
@@ -22,6 +22,7 @@ depends="
 	libxcb
 	libXfixes
 	libxkbcommon
+	libdrm
 	pango
 	pixman
 	polkit


### PR DESCRIPTION
My hyprland didn't start after the update because of undefined symbols originating from me still using the old version of libdrm, and not the one included in this repository. Should probably be a dependency so that libdrm is updated along with hyprland. 