### PR TITLE
add musl keyword patch

### DIFF
--- a/srcpkgs/hyprland/patches/keyword.patch
+++ b/srcpkgs/hyprland/patches/keyword.patch
@@ -1,0 +1,15 @@
+diff '--color=auto' -aru a/src/plugins/HookSystem.cpp b/src/plugins/HookSystem.cpp
+--- a/src/plugins/HookSystem.cpp	2024-01-01 13:13:39.000000000 +0100
++++ b/src/plugins/HookSystem.cpp	2024-02-04 21:08:14.574702286 +0100
+@@ -190,9 +190,9 @@
+         (uint64_t)((uint8_t*)m_pSource + sizeof(ABSOLUTE_JMP_ADDRESS));
+ 
+     // make jump to hk
+-    const auto     PAGESIZE  = sysconf(_SC_PAGE_SIZE);
+-    const uint8_t* PROTSTART = (uint8_t*)m_pSource - ((uint64_t)m_pSource % PAGESIZE);
+-    const size_t   PROTLEN   = std::ceil((float)(ORIGSIZE + ((uint64_t)m_pSource - (uint64_t)PROTSTART)) / (float)PAGESIZE) * PAGESIZE;
++    const auto     CIRC_PAGESIZE  = sysconf(_SC_PAGE_SIZE);
++    const uint8_t* PROTSTART = (uint8_t*)m_pSource - ((uint64_t)m_pSource % CIRC_PAGESIZE);
++    const size_t   PROTLEN   = std::ceil((float)(ORIGSIZE + ((uint64_t)m_pSource - (uint64_t)PROTSTART)) / (float)CIRC_PAGESIZE) * CIRC_PAGESIZE;
+     mprotect((uint8_t*)PROTSTART, PROTLEN, PROT_READ | PROT_WRITE | PROT_EXEC);
+     memcpy((uint8_t*)m_pSource, ABSOLUTE_JMP_ADDRESS, sizeof(ABSOLUTE_JMP_ADDRESS));


### PR DESCRIPTION
Changes the name of the `PAGESIZE` variable since that seems to be defined as a macro under musl systems.