### PR TITLE
hyprlang 0.4.0, hypridle 0.1.0, hyprlock 0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,5 +105,7 @@ This repository also includes other templates which may be of interest for:
 
 - hyprpaper
 - xdg-desktop-portal-hyprland
+- hypridle
+- hyprlock
 
 You may also be interested in [EWW](https://github.com/elkowar/eww), for which a template is available in a [separate repository](https://github.com/Makrennel/eww-void) as it is not specific to Hyprland.

--- a/common/shlibs
+++ b/common/shlibs
@@ -1,4 +1,5 @@
 libliftoff.so.0 libliftoff-0.4.1_1
 libsdbus-c++.so.1 sdbus-cpp-1.4.0_1
-libhyprlang.so hyprlang-0.2.1_1
+libhyprlang.so hyprlang-0.4.0_1
+libhyprlang.so.1 hyprlang-0.4.0_1
 libtomlplusplus.so.3 tomlplusplus-3.4.0_1

--- a/srcpkgs/hypridle/template
+++ b/srcpkgs/hypridle/template
@@ -1,0 +1,15 @@
+# Template file for 'hypridle'
+pkgname=hypridle
+version=0.1.0
+revision=1
+build_style=cmake
+hostmakedepends="cmake pkg-config"
+makedepends="wayland-devel wayland-protocols hyprlang sdbus-cpp"
+depends=""
+short_desc="Hyprland's idle daemon"
+maintainer="Makrennel <makrommel@protonmail.ch>"
+license="BSD"
+homepage="https://github.com/hyprwm/hypridle"
+distfiles="https://github.com/hyprwm/hypridle/archive/refs/tags/v${version}.tar.gz"
+checksum=142cceacd91bf7f0bf6ae0e4e298f7375a5c6d38216756062e415dbf93f3b317
+

--- a/srcpkgs/hyprlang/template
+++ b/srcpkgs/hyprlang/template
@@ -1,13 +1,13 @@
-# Template file for 'hyprlang'
 pkgname=hyprlang
-version=0.2.1
+version=0.4.0
 revision=1
 build_style=cmake
 hostmakedepends="cmake pkg-config"
-short_desc="Official implementation library for the hypr config language"
+short_desc="The official implementation library for the hypr config language."
 maintainer="Makrennel <makrommel@protonmail.ch>"
-license="GPL-3.0-only"
-homepage="https://hyprland.org/hyprlang/index.html"
+license="GPL-3.0"
+homepage="https://hyprland.org/${pkgname}/index.html"
 changelog="https://github.com/hyprwm/${pkgname}/releases"
 distfiles="https://github.com/hyprwm/hyprlang/archive/refs/tags/v${version}.tar.gz"
-checksum=e41b265f09c1e84e03f052f584fcc086fe48ec5057191ef35917ce79e7dc4190
+checksum=d50e66a46445fc322e3a0065ad1b86799d3c1e9d22d5a179f74b71e520aa82bb
+

--- a/srcpkgs/hyprlock/template
+++ b/srcpkgs/hyprlock/template
@@ -1,0 +1,17 @@
+# Template file for 'hyprlock'
+pkgname=hyprlock
+version=0.1.0
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config cmake"
+makedepends="pango-devel cairo-devel
+        hyprlang wayland-protocols wayland-devel
+        libdrm-devel libxkbcommon-devel pam-devel MesaLib-devel"
+depends=""
+short_desc="Hyprland's simple, yet multi-threaded and GPU-accelerated screen locking utility."
+maintainer="Makrennel <makrommel@protonmail.ch>"
+license="BSD"
+homepage="https://github.com/hyprwm/hyprlock"
+distfiles="https://github.com/hyprwm/hyprlock/archive/refs/tags/v${version}.tar.gz"
+checksum=5d0e6547ac073c78e95d4f086a258e1e5713168827c38ccb2466f2c4d96bd1df
+


### PR DESCRIPTION
With upgrade of hyprlang (0.4.0 is needed by those new packages) I had to rebuild and reinstall also hyprpaper and xdg-desktop-portal-hyprland.

Hypridle was developed since 0.1.0 but there is no new release (maybe should wait a bit).
To fix small bug ([Issue](https://github.com/hyprwm/hypridle/issues/7)), I run it like this in my hyprland.conf:
`exec = pkill hypridle || (hypridle &) && sleep 1 && loginctl unlock-session`