### PR TITLE
hyprland: update to 0.36.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ sudo xbps-install -Su
 This repository also includes other templates which may be of interest for:
 
 - hyprpaper
+- hypridle
 - xdg-desktop-portal-hyprland
 
 You may also be interested in [EWW](https://github.com/elkowar/eww), for which a template is available in a [separate repository](https://github.com/Makrennel/eww-void) as it is not specific to Hyprland.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This repository also includes other templates which may be of interest for:
 
 - hyprpaper
 - hypridle
+- hyprlock
 - xdg-desktop-portal-hyprland
 
 You may also be interested in [EWW](https://github.com/elkowar/eww), for which a template is available in a [separate repository](https://github.com/Makrennel/eww-void) as it is not specific to Hyprland.

--- a/common/shlibs
+++ b/common/shlibs
@@ -1,4 +1,4 @@
 libliftoff.so.0 libliftoff-0.4.1_1
 libsdbus-c++.so.1 sdbus-cpp-1.4.0_1
-libhyprlang.so hyprlang-0.2.1_1
+libhyprlang.so.1 hyprlang-0.4.1_1
 libtomlplusplus.so.3 tomlplusplus-3.4.0_1

--- a/srcpkgs/hypridle/template
+++ b/srcpkgs/hypridle/template
@@ -1,0 +1,15 @@
+# Template file for 'hypridle'
+pkgname=hypridle
+version=0.1.0
+revision=1
+build_style=cmake
+hostmakedepends="cmake pkg-config"
+makedepends="wayland-devel wayland-protocols hyprlang sdbus-cpp"
+depends=""
+short_desc="Hyprland's idle daemon"
+maintainer="Makrennel <makrommel@protonmail.ch>"
+license="BSD"
+homepage="https://github.com/hyprwm/hypridle"
+distfiles="https://github.com/hyprwm/hypridle/archive/refs/tags/v${version}.tar.gz"
+checksum=142cceacd91bf7f0bf6ae0e4e298f7375a5c6d38216756062e415dbf93f3b317
+

--- a/srcpkgs/hyprland/template
+++ b/srcpkgs/hyprland/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprland'
 pkgname=hyprland
-version=0.35.0
+version=0.36.0
 revision=1
 build_style=cmake
 hostmakedepends="jq git pkg-config glslang hwids meson ninja autoconf mk-configure"
@@ -46,7 +46,7 @@ license="BSD-3-Clause"
 homepage="https://hyprland.org/"
 changelog="https://github.com/hyprwm/Hyprland/releases"
 distfiles="https://github.com/hyprwm/Hyprland/releases/download/v${version}/source-v${version}.tar.gz"
-checksum=de53d764606131c8aacc209f8a3ad6e619fdcddd16a7cdf4d8ca343816bb8c1b
+checksum=8e44c379794663accf928458b5e363ed248d56fc5f267e6b3759146fdf1229bb
 
 if [ "$XBPS_TARGET_LIBC" = musl ]; then
 	makedepends+=" libexecinfo-devel"

--- a/srcpkgs/hyprlang/template
+++ b/srcpkgs/hyprlang/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprlang'
 pkgname=hyprlang
-version=0.2.1
+version=0.4.1
 revision=1
 build_style=cmake
 hostmakedepends="cmake pkg-config"
@@ -10,4 +10,4 @@ license="GPL-3.0-only"
 homepage="https://hyprland.org/hyprlang/index.html"
 changelog="https://github.com/hyprwm/${pkgname}/releases"
 distfiles="https://github.com/hyprwm/hyprlang/archive/refs/tags/v${version}.tar.gz"
-checksum=e41b265f09c1e84e03f052f584fcc086fe48ec5057191ef35917ce79e7dc4190
+checksum=dd00b48fc31199c3f30f4ef6ec61f3bddcc092eff2628ee28cb238a4501521e8

--- a/srcpkgs/hyprlock/template
+++ b/srcpkgs/hyprlock/template
@@ -1,0 +1,17 @@
+# Template file for 'hyprlock'
+pkgname=hyprlock
+version=0.1.0
+revision=1
+build_style=cmake
+hostmakedepends="pkg-config cmake"
+makedepends="pango-devel cairo-devel
+        hyprlang wayland-protocols wayland-devel
+        libdrm-devel libxkbcommon-devel pam-devel MesaLib-devel"
+depends=""
+short_desc="Hyprland's simple, yet multi-threaded and GPU-accelerated screen locking utility."
+maintainer="Makrennel <makrommel@protonmail.ch>"
+license="BSD"
+homepage="https://github.com/hyprwm/hyprlock"
+distfiles="https://github.com/hyprwm/hyprlock/archive/refs/tags/v${version}.tar.gz"
+checksum=5d0e6547ac073c78e95d4f086a258e1e5713168827c38ccb2466f2c4d96bd1df
+

--- a/srcpkgs/xdg-desktop-portal-hyprland/template
+++ b/srcpkgs/xdg-desktop-portal-hyprland/template
@@ -1,7 +1,7 @@
 # Template file for 'xdg-desktop-portal-hyprland'
 pkgname=xdg-desktop-portal-hyprland
 version=1.3.1
-revision=1
+revision=2
 build_style=cmake
 hostmakedepends="
 	pkg-config


### PR DESCRIPTION
closes #34 
bumped revision in xdg-desktop-portal-hyprland to trigger rebuild after hyprlang update

Included hyprlock and hypridle from other PR. Not sure if is needed.

But needed will be hyprctl.

Will add later...