### PR TITLE
Update sdbus-cpp, hypridle, hyprlock and xdph

### DIFF
--- a/srcpkgs/hypridle/template
+++ b/srcpkgs/hypridle/template
@@ -1,6 +1,6 @@
 # Template file for 'hypridle'
 pkgname=hypridle
-version=0.1.2
+version=0.1.4
 revision=1
 build_style=cmake
 hostmakedepends="cmake pkgconf"
@@ -11,7 +11,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/hyprwm/hypridle"
 changelog="https://github.com/hyprwm/${pkgname}/releases"
 distfiles="https://github.com/hyprwm/hypridle/archive/refs/tags/v${version}.tar.gz"
-checksum=40ab0bc7183e880f46fcc2d24b182226a5dfd8ce7695af6c320527eccf8d7c79
+checksum=4a878917be65ab2df24f9036846339610861b845b9f1bb9ca0bdffdc1e368050
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/hyprlock/template
+++ b/srcpkgs/hyprlock/template
@@ -1,17 +1,17 @@
 # Template file for 'hyprlock'
 pkgname=hyprlock
-version=0.4.1
+version=0.5.0
 revision=1
 build_style=cmake
 hostmakedepends="cmake pkgconf"
-makedepends="cairo-devel hyprlang libdrm-devel libxkbcommon-devel MesaLib-devel pango-devel pam-devel wayland-devel wayland-protocols hyprutils libjpeg-turbo-devel libwebp-devel file-devel"
+makedepends="cairo-devel hyprlang libdrm-devel libxkbcommon-devel MesaLib-devel pango-devel pam-devel wayland-devel wayland-protocols hyprutils libjpeg-turbo-devel libwebp-devel file-devel sdbus-cpp"
 short_desc="Hyprland's GPU-accelerated screen locking utility"
 maintainer="Makrennel <makrommel@protonmail.ch>"
 license="BSD-3-Clause"
 homepage="https://github.com/hyprwm/hyprlock"
 changelog="https://github.com/hyprwm/${pkgname}/releases"
 distfiles="https://github.com/hyprwm/${pkgname}/archive/refs/tags/v${version}.tar.gz"
-checksum=87531a43088cafcadf29115889f37f73ab4a8cb1e4347723dfe8d53fa0aaba60
+checksum=4f8a0199de205ad21a4e3da88c0196514a0ba3c6162e44f93e7cfb96371daf99
 
 post_install() {
 	vlicense LICENSE

--- a/srcpkgs/sdbus-cpp/template
+++ b/srcpkgs/sdbus-cpp/template
@@ -1,6 +1,6 @@
 # Template file for 'sdbus-cpp'
 pkgname=sdbus-cpp
-version=1.5.0
+version=2.0.0
 revision=1
 build_style=cmake
 hostmakedepends="cmake meson ninja pkgconf git m4 rsync gperf"
@@ -12,4 +12,4 @@ license="LGPL-2.1-only"
 homepage="https://github.com/Kistler-Group/sdbus-cpp"
 changelog="https://github.com/Kistler-Group/${pkgname}/releases"
 distfiles="https://github.com/Kistler-Group/${pkgname}/archive/refs/tags/v${version}.tar.gz"
-checksum=577986929f911320fb9ef6a3e2badd464dc38411ebc25d2966f5cb85c39f0897
+checksum=88af4569161a0d0192f0f4a94582a1af4e75722499d06984fb7f91f638f5afb3

--- a/srcpkgs/xdg-desktop-portal-hyprland/template
+++ b/srcpkgs/xdg-desktop-portal-hyprland/template
@@ -1,6 +1,6 @@
 # Template file for 'xdg-desktop-portal-hyprland'
 pkgname=xdg-desktop-portal-hyprland
-version=1.3.6
+version=1.3.7
 revision=1
 build_style=cmake
 hostmakedepends="
@@ -39,7 +39,7 @@ maintainer="Makrennel <makrommel@protonmail.ch>"
 license="BSD-3-Clause"
 homepage="https://github.com/hyprwm/xdg-desktop-portal-hyprland"
 distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
-checksum=cf9742c5a6df3de58abf631f01d58c5df0db417004aa8e6852f6533cc8f2938e
+checksum=a45268501442e20f20763d023b8e97f3fc40d82ab42493fb3209aeb607ea2033
 
 post_install() {
 	vlicense LICENSE


### PR DESCRIPTION
Update sdb-cpp to v2.0.0 and it's dependant packages (hypridle, hyprlock, xdph)