### PR TITLE
Update Hyprland to v0.49.0 and all packages (except glaze) to latest releases

### DIFF
--- a/common/shlibs
+++ b/common/shlibs
@@ -1,8 +1,8 @@
-libaquamarine.so.7 aquamarine-0.8.0_1
+libaquamarine.so.7 aquamarine-0.8.0_2
 libhyprcursor.so.0 hyprcursor-0.1.12_1
-libhyprlang.so.2 hyprlang-0.6.1_1
-libhyprgraphics.so.0 hyprgraphics-0.1.3_1
-libhyprutils.so.4 hyprutils-0.5.2_1
-libsdbus-c++.so.2 sdbus-cpp-2.0.0_1
+libhyprlang.so.2 hyprlang-0.6.3_1
+libhyprgraphics.so.0 hyprgraphics-0.1.3_2
+libhyprutils.so.6 hyprutils-0.7.1_1
+libsdbus-c++.so.2 sdbus-cpp-2.1.0_1
 libspng.so.0 libspng-0.7.4_1
 libtomlplusplus.so.3 tomlplusplus-3.4.0_1

--- a/srcpkgs/aquamarine/template
+++ b/srcpkgs/aquamarine/template
@@ -1,7 +1,7 @@
 # Template file for 'aquamarine'
 pkgname=aquamarine
 version=0.8.0
-revision=1
+revision=2
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
 configure_args+=" -DCMAKE_BUILD_TYPE:STRING=Release"

--- a/srcpkgs/hyprgraphics/template
+++ b/srcpkgs/hyprgraphics/template
@@ -1,7 +1,7 @@
 # Template file for 'hyprgraphics'
 pkgname=hyprgraphics
 version=0.1.3
-revision=1
+revision=2
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
 configure_args+=" -DCMAKE_BUILD_TYPE:STRING=Release"

--- a/srcpkgs/hypridle/template
+++ b/srcpkgs/hypridle/template
@@ -1,7 +1,7 @@
 # Template file for 'hypridle'
 pkgname=hypridle
 version=0.1.6
-revision=1
+revision=2
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
 configure_args+=" -DCMAKE_BUILD_TYPE:STRING=Release"

--- a/srcpkgs/hyprland-qtutils/template
+++ b/srcpkgs/hyprland-qtutils/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprland-qtutils'
 pkgname=hyprland-qtutils
-version=0.1.3
+version=0.1.4
 revision=1
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
@@ -30,7 +30,7 @@ maintainer="Makrennel <makrommel@protonmail.ch>"
 license="BSD-3-Clause"
 homepage="https://github.com/hyprwm/hyprland-qtutils"
 distfiles="https://github.com/hyprwm/hyprland-qtutils/archive/refs/tags/v${version}.tar.gz"
-checksum=3e57617ebd849ebf074c492bf828efa37a5b47fd6d43b392462874069170c5ed
+checksum="56a83f4625feeed86bbc5d744b91d2074330c5aa41adf6e32c023f06f9fb9d34"
 
 post_install() {
   vlicense LICENSE

--- a/srcpkgs/hyprland/patches/musl-build-fix.patch
+++ b/srcpkgs/hyprland/patches/musl-build-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/HyprlandSocket.cpp.e b/HyprlandSocket.cpp
+index 4d86192..50b3558 100644
+--- a/hyprpm/src/core/HyprlandSocket.cpp
++++ b/hyprpm/src/core/HyprlandSocket.cpp
+@@ -5,6 +5,7 @@
+ #include <print>
+ #include <sys/un.h>
+ #include <unistd.h>
++#include <cstring>
+ 
+ static int getUID() {
+     const auto UID   = getuid();

--- a/srcpkgs/hyprland/template
+++ b/srcpkgs/hyprland/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprland'
 pkgname=hyprland
-version=0.48.1
+version=0.49.0
 revision=1
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
@@ -56,7 +56,7 @@ license="BSD-3-Clause"
 homepage="https://hyprland.org/"
 changelog="https://github.com/hyprwm/Hyprland/releases"
 distfiles="https://github.com/hyprwm/Hyprland/releases/download/v${version}/source-v${version}.tar.gz"
-checksum=0106a0c38d1a5f6f2a7ba1cbbbcb4e77724535bb7e8caf5a145248f5e11137a6
+checksum="fd96fb043cfeda09a1ab9a5eb69fee55562475c0c6a41f79dad2bcc652dc5730"
 
 if [ "$XBPS_TARGET_LIBC" = "musl" ]; then
   configure_args+=" -DCMAKE_CXX_FLAGS=\"-lexecinfo\""

--- a/srcpkgs/hyprlang/template
+++ b/srcpkgs/hyprlang/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprlang'
 pkgname=hyprlang
-version=0.6.1
+version=0.6.3
 revision=1
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
@@ -19,5 +19,4 @@ license="LGPL-3.0-only"
 homepage="https://hyprland.org/hyprlang/index.html"
 changelog="https://github.com/hyprwm/hyprlang/releases"
 distfiles="https://github.com/hyprwm/hyprlang/archive/refs/tags/v${version}.tar.gz"
-checksum=8537bb112c633b3463850747d1fd29e1e1884df2cc4659c12736b941ba06e6bb
-
+checksum=f5effe017edc7a0036c20c7ecbea4edc2bfdacbc0f791b283bd21ec202384251

--- a/srcpkgs/hyprlock/template
+++ b/srcpkgs/hyprlock/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprlock'
 pkgname=hyprlock
-version=0.8.0
+version=0.8.2
 revision=1
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
@@ -36,7 +36,7 @@ license="BSD-3-Clause"
 homepage="https://github.com/hyprwm/hyprlock"
 changelog="https://github.com/hyprwm/${pkgname}/releases"
 distfiles="https://github.com/hyprwm/${pkgname}/archive/refs/tags/v${version}.tar.gz"
-checksum=70154a004a270cd91cb62031314e8371dc32c636d68b8bb979afd238dd501ccf
+checksum="14c47e71bdac9213909b11cdda16377dab12e27179d939df5ef2a0083a21e1e8"
 
 post_install() {
   vlicense LICENSE

--- a/srcpkgs/hyprpaper/template
+++ b/srcpkgs/hyprpaper/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprpaper'
 pkgname=hyprpaper
-version=0.7.4
+version=0.7.5
 revision=1
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"

--- a/srcpkgs/hyprpaper/template
+++ b/srcpkgs/hyprpaper/template
@@ -31,7 +31,7 @@ maintainer="Makrennel <makrommel@protonmail.ch>"
 license="BSD-3-Clause"
 homepage="https://github.com/hyprwm/hyprpaper"
 distfiles="${homepage}/archive/refs/tags/v${version}.tar.gz"
-checksum=a2375dae58d29293b942a60cd465771b2c3c85cfcac628ec4897f11e7008666f
+checksum="93efc089c7051e6727ac5eac402ebd254199e93ac3efd6fe7dd37a52ddc1cc33"
 
 post_install() {
   vlicense LICENSE

--- a/srcpkgs/hyprutils/template
+++ b/srcpkgs/hyprutils/template
@@ -1,6 +1,6 @@
 # Template file for 'hyprutils'
 pkgname=hyprutils
-version=0.5.2
+version=0.7.1
 revision=1
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
@@ -17,7 +17,7 @@ maintainer="Makrennel <makrommel@protonmail.ch>"
 license="BSD-3-Clause"
 homepage="https://github.com/hyprwm/hyprutils"
 distfiles="https://github.com/hyprwm/hyprutils/archive/refs/tags/v${version}.tar.gz"
-checksum=b30b93be9597489bd5a29c8cd91d60ea0fcaea08fd03cca1368e101c4ae19d3d
+checksum=bcbf05252b392b8837eec9ba9855ff6ddab571f9795917c7139215ae4b2cf1bc
 
 post_install() {
   vlicense LICENSE

--- a/srcpkgs/sdbus-cpp/template
+++ b/srcpkgs/sdbus-cpp/template
@@ -1,6 +1,6 @@
 # Template file for 'sdbus-cpp'
 pkgname=sdbus-cpp
-version=2.0.0
+version=2.1.0
 revision=1
 build_style=cmake
 hostmakedepends="
@@ -26,7 +26,7 @@ license="LGPL-2.1-only"
 homepage="https://github.com/Kistler-Group/sdbus-cpp"
 changelog="https://github.com/Kistler-Group/${pkgname}/releases"
 distfiles="https://github.com/Kistler-Group/${pkgname}/archive/refs/tags/v${version}.tar.gz"
-checksum=88af4569161a0d0192f0f4a94582a1af4e75722499d06984fb7f91f638f5afb3
+checksum=6025e5dc6cddd532ff960d14e68ced5f42a1916b23a73fea6bcb437f06992eaf
 
 post_install() {
   vlicense COPYING

--- a/srcpkgs/xdg-desktop-portal-hyprland/template
+++ b/srcpkgs/xdg-desktop-portal-hyprland/template
@@ -1,7 +1,7 @@
 # Template file for 'xdg-desktop-portal-hyprland'
 pkgname=xdg-desktop-portal-hyprland
 version=1.3.9
-revision=1
+revision=2
 build_style=cmake
 configure_args+=" --no-warn-unused-cli"
 configure_args+=" -DCMAKE_INSTALL_PREFIX:PATH=/usr"


### PR DESCRIPTION
Updated hyprland to v0.49.0 and other packages (except glaze) to latest versions.